### PR TITLE
Corrected all known issues for systems running PHP 7.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@
 #### Install the packages we need.
 `apt-get install apache2 git mysql-server php5-mysqlnd youtube-dl`
 
+#### For Systems running php7.x
+`apt-get install apache2 libapache2-mod-php git mysql-server youtube-dl`
+
 #############################################################################
 #### Move to the root home folder.
 `cd`

--- a/scripts/local_download.php
+++ b/scripts/local_download.php
@@ -182,14 +182,14 @@ function serve($filename, $download){
 	// header("Content-Type: application/pdf");
 	header("Content-Type: application/octet-stream");
 	$filename_parts=pathinfo($filename);
-	if($download) header('Content-disposition: attachment; filename='.$filename_parts['basename']);
+	if($download) header("Content-disposition: attachment; filename=\"".$filename_parts['basename']."\"");
 	readfile($filename);
 }
 
 //unset magic quotes; otherwise, file contents will be modified
-// Commented this out as it is no longer a function in PHP 7.x
-//set_magic_quotes_runtime(0);
-
+if(get_magic_quotes_runtime()){
+	ini_set('magic_quotes_runtime', 0);
+}
 //do not send cache limiter header
 ini_set('session.cache_limiter','none');
 

--- a/scripts/local_download.php
+++ b/scripts/local_download.php
@@ -187,7 +187,8 @@ function serve($filename, $download){
 }
 
 //unset magic quotes; otherwise, file contents will be modified
-set_magic_quotes_runtime(0);
+// Commented this out as it is no longer a function in PHP 7.x
+//set_magic_quotes_runtime(0);
 
 //do not send cache limiter header
 ini_set('session.cache_limiter','none');

--- a/scripts/play_media.php
+++ b/scripts/play_media.php
@@ -4,7 +4,7 @@ $timestamp = $_GET['timestamp'];
 $media = addslashes($_GET['media']);
 $page = $_GET['page'];
 $public = $_GET['public'];
-$filename="$page/$timestamp/$media"; //compose filename to pass to local_download.php
+$filename=mysqli_real_escape_string($db,"$page/$timestamp/$media"); //compose filename to pass to local_download.php
 
 echo "<div id=\"content\">";
 
@@ -24,7 +24,7 @@ if ($_GET['page'] == "videos") {
 					</audio>
 	<a class=\"download_link\" href=\"./local_download.php?filename=$filename&public=$public&dtype=true\">Download</a>";
 }
-echo "</div>
+echo $filename;"</div>
 </div>";
 include("footer.php");
 ?>


### PR DESCRIPTION
I have added a logic block that should allow backwards compatibility to php 5.x and forward to php 7.x.  I have also corrected the issue with titles that have spaces dropping the title after the first space.  I believe this was an issue tied to no longer using magic_quotes function in php7.x.